### PR TITLE
fix(workflow): update project board automation with graphql api

### DIFF
--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -12,6 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: TimonVS/pr-labeler-action@v3
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
         with:
           configuration-path: .github/pr-labeler.yml
-          repo-token: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/project-automation.yml
+++ b/.github/workflows/project-automation.yml
@@ -63,17 +63,30 @@ jobs:
 
       - name: Update PR status
         if: github.event_name == 'pull_request'
-        uses: actions/github-script@v6
-        with:
-          github-token: ${{ secrets.GH_TOKEN }}
-          script: |
-            const status = context.payload.action === 'opened' ? '🏗️ In Progress' :
-                          context.payload.action === 'ready_for_review' ? '👀 Review' :
-                          (context.payload.action === 'closed' || context.payload.pull_request.merged) ? '✅ Done' : null;
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+        run: |
+          STATUS_VALUE=""
+          if [[ "${{ github.event.action }}" == "opened" ]]; then
+            STATUS_VALUE="${{ env.IN_PROGRESS_OPTION_ID }}"
+          elif [[ "${{ github.event.action }}" == "ready_for_review" ]]; then
+            STATUS_VALUE="${{ env.REVIEW_OPTION_ID }}"
+          elif [[ "${{ github.event.action }}" == "closed" && "${{ github.event.pull_request.merged }}" == "true" ]]; then
+            STATUS_VALUE="${{ env.DONE_OPTION_ID }}"
+          fi
 
-            if (status) {
-              await github.rest.projects.updateCard({
-                card_id: context.payload.project_card.id,
-                column_name: status
-              });
-            }
+          if [[ -n "$STATUS_VALUE" ]]; then
+            gh api graphql -f query='
+              mutation($project:ID!, $item:ID!, $field:ID!, $value:String!) {
+                updateProjectV2ItemFieldValue(
+                  input: {
+                    projectId: $project
+                    itemId: $item
+                    fieldId: $field
+                    value: { singleSelectOptionId: $value }
+                  }
+                ) {
+                  projectV2Item { id }
+                }
+              }' -f project=${{ env.PROJECT_ID }} -f item=${{ steps.add-to-project.outputs.itemId }} -f field=${{ env.STATUS_FIELD_ID }} -f value=$STATUS_VALUE
+          fi

--- a/.github/workflows/project-automation.yml
+++ b/.github/workflows/project-automation.yml
@@ -28,25 +28,38 @@ jobs:
           echo 'DONE_OPTION_ID=9dc3432f' >> $GITHUB_ENV
 
       - uses: actions/add-to-project@v0.5.0
+        id: add-to-project
         with:
           project-url: https://github.com/users/rafaumeu/projects/4
           github-token: ${{ secrets.GH_TOKEN }}
 
       - name: Update issue status
         if: github.event_name == 'issues'
-        uses: actions/github-script@v6
-        with:
-          github-token: ${{ secrets.GH_TOKEN }}
-          script: |
-            const status = context.payload.action === 'opened' ? '🎯 Backlog' :
-                          context.payload.action === 'closed' ? '✅ Done' : null;
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+        run: |
+          STATUS_VALUE=""
+          if [[ "${{ github.event.action }}" == "opened" ]]; then
+            STATUS_VALUE="${{ env.BACKLOG_OPTION_ID }}"
+          elif [[ "${{ github.event.action }}" == "closed" ]]; then
+            STATUS_VALUE="${{ env.DONE_OPTION_ID }}"
+          fi
 
-            if (status) {
-              await github.rest.projects.updateCard({
-                card_id: context.payload.project_card.id,
-                column_name: status
-              });
-            }
+          if [[ -n "$STATUS_VALUE" ]]; then
+            gh api graphql -f query='
+              mutation($project:ID!, $item:ID!, $field:ID!, $value:String!) {
+                updateProjectV2ItemFieldValue(
+                  input: {
+                    projectId: $project
+                    itemId: $item
+                    fieldId: $field
+                    value: { singleSelectOptionId: $value }
+                  }
+                ) {
+                  projectV2Item { id }
+                }
+              }' -f project=${{ env.PROJECT_ID }} -f item=${{ steps.add-to-project.outputs.itemId }} -f field=${{ env.STATUS_FIELD_ID }} -f value=$STATUS_VALUE
+          fi
 
       - name: Update PR status
         if: github.event_name == 'pull_request'


### PR DESCRIPTION
## Changes

- Remove invalid projects permission
- Update issue status update logic using GraphQL API
- Add proper error handling for project board automation

## Testing
- [ ] Issue is added to project board
- [ ] Status updates correctly on issue events
- [ ] Status updates correctly on PR events

Fixes #<issue_number>